### PR TITLE
Use pending and shared state resolvers

### DIFF
--- a/code/audience/src/androidTest/java/com/adobe/marketing/mobile/audience/AudienceFunctionalTests.java
+++ b/code/audience/src/androidTest/java/com/adobe/marketing/mobile/audience/AudienceFunctionalTests.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -381,7 +380,6 @@ public class AudienceFunctionalTests {
 		assertNull(requests.get(1).getHeaders());
 	}
 
-	@Ignore("investigate: Cannot create com.adobe.module.audience shared state at version 4. More recent state exists.")
 	@Test
 	public void testSubmitSignal_WhenEverythingIsSetAndServerResponse_updatesSharedState() throws Exception {
 		// setup
@@ -395,7 +393,6 @@ public class AudienceFunctionalTests {
 		);
 		testableNetworkService.setExpectedNetworkRequest(signalRequest, 1);
 
-		// preset the config
 		registerExtensions(config);
 
 		// test
@@ -411,7 +408,7 @@ public class AudienceFunctionalTests {
 		assertNotNull(sharedState);
 		assertEquals(2, sharedState.size());
 		assertEquals(expectedProfile, DataReader.optStringMap(sharedState, "aamprofile", null));
-		assertEquals("testUUID", DataReader.optString(sharedState, "uuid", null));
+		assertEquals("19994521975870785742420741570375407533", DataReader.optString(sharedState, "uuid", null));
 	}
 
 	@Test

--- a/code/audience/src/main/java/com/adobe/marketing/mobile/audience/AudienceExtension.java
+++ b/code/audience/src/main/java/com/adobe/marketing/mobile/audience/AudienceExtension.java
@@ -610,7 +610,9 @@ public final class AudienceExtension extends Extension {
 
 		// prepare shared state for this asynchronous processing of this event
 		SharedStateResolver ssResolver = getApi().createPendingSharedState(event);
-		pendingSharedStates.put(event.getUniqueIdentifier(), ssResolver);
+		if (ssResolver != null) {
+			pendingSharedStates.put(event.getUniqueIdentifier(), ssResolver);
+		}
 
 		Map<String, String> signalData;
 

--- a/code/audience/src/main/java/com/adobe/marketing/mobile/audience/AudienceExtension.java
+++ b/code/audience/src/main/java/com/adobe/marketing/mobile/audience/AudienceExtension.java
@@ -24,6 +24,7 @@ import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.MobilePrivacyStatus;
 import com.adobe.marketing.mobile.SharedStateResolution;
+import com.adobe.marketing.mobile.SharedStateResolver;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
 import com.adobe.marketing.mobile.services.DataQueue;
@@ -44,6 +45,8 @@ import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -81,6 +84,7 @@ public final class AudienceExtension extends Extension {
 
 	private final AudienceState internalState;
 	private PersistentHitQueue hitQueue;
+	private ConcurrentMap<String, SharedStateResolver> pendingSharedStates;
 
 	@VisibleForTesting
 	final AudienceNetworkResponseHandler networkResponseHandler;
@@ -107,6 +111,7 @@ public final class AudienceExtension extends Extension {
 					LOG_SOURCE,
 					"Not dispatching Audience hit response since resetIdentities API was called after queuing this hit."
 				);
+				resolveShareStateForEvent(requestEvent);
 				return;
 			}
 
@@ -114,12 +119,14 @@ public final class AudienceExtension extends Extension {
 
 			if (StringUtils.isNullOrEmpty(responsePayload)) {
 				Log.debug(LOG_TAG, LOG_SOURCE, "Null/empty response from server, nothing to process.");
+				resolveShareStateForEvent(requestEvent);
 				dispatchAudienceResponseContent(profile, requestEvent);
 				return;
 			}
 
 			// process the response from the AAM server and share the shared state
 			profile = processResponse(responsePayload, requestEvent);
+			resolveShareStateForEvent(requestEvent);
 
 			// if profile is empty, there was a json error in the response, don't dispatch a generic event
 			if (profile != null && !profile.isEmpty()) {
@@ -142,6 +149,7 @@ public final class AudienceExtension extends Extension {
 		final PersistentHitQueue hitQueue
 	) {
 		super(extensionApi);
+		this.pendingSharedStates = new ConcurrentHashMap<>();
 		this.internalState = audienceState != null ? audienceState : new AudienceState();
 		networkResponseHandler = new NetworkResponseHandler(internalState);
 		if (hitQueue == null) {
@@ -366,7 +374,7 @@ public final class AudienceExtension extends Extension {
 	 */
 	@VisibleForTesting
 	void handleLifecycleResponse(@NonNull final Event event) {
-		// if aam forwarding is enabled, we don't need to send anything
+		// if aam forwarding is enabled, we don't need to send lifecycle hit
 		if (serverSideForwardingToAam(event)) {
 			Log.trace(
 				LOG_TAG,
@@ -382,30 +390,7 @@ public final class AudienceExtension extends Extension {
 			return;
 		}
 
-		// send a signal
-		final Map<String, String> tempLifecycleData = DataReader.optStringMap(
-			eventData,
-			AudienceConstants.EventDataKeys.Lifecycle.LIFECYCLE_CONTEXT_DATA,
-			null
-		);
-		final Map<String, String> lifecycleContextData = getLifecycleDataForAudience(tempLifecycleData);
-
-		final Map<String, Object> newEventData = new HashMap<String, Object>() {
-			{
-				put(AudienceConstants.EventDataKeys.Audience.VISITOR_TRAITS, lifecycleContextData);
-			}
-		};
-
-		final Event newCurrentEvent = new Event.Builder(
-			"Audience Manager Profile",
-			EventType.AUDIENCEMANAGER,
-			EventSource.RESPONSE_CONTENT
-		)
-			.setEventData(newEventData)
-			.build();
-
-		// TODO: set timestamp and event number???
-		submitSignal(newCurrentEvent);
+		submitSignal(event);
 	}
 
 	//endregion
@@ -495,17 +480,43 @@ public final class AudienceExtension extends Extension {
 		// Setting the visitor profile may fail if the AudienceState's current privacy is opt-out
 		internalState.setVisitorProfile(returnedMap);
 
-		shareStateForEvent(event);
-
 		return returnedMap;
 	}
 
+	/**
+	 * Retrieves last set shared state for the given extension name
+	 * @param extensionName shared state owner for which to get the shared state
+	 * @param event current event
+	 * @return {@link SharedStateResult}
+	 */
 	private SharedStateResult getSharedStateForExtension(final String extensionName, final Event event) {
 		return getApi().getSharedState(extensionName, event, false, SharedStateResolution.LAST_SET);
 	}
 
+	/**
+	 * Creates a shared state for the provided event with current state data
+	 * @param event the event for which to create the state
+	 */
 	private void shareStateForEvent(final Event event) {
 		getApi().createSharedState(internalState.getStateData(), event);
+	}
+
+	/**
+	 * Resolves the previously set pending shared state for the given event with current state data
+	 * @param event the event for which to resolve the state
+	 */
+	private void resolveShareStateForEvent(final Event event) {
+		if (event == null) {
+			return;
+		}
+
+		SharedStateResolver resolver = pendingSharedStates.get(event.getUniqueIdentifier());
+		if (resolver == null) {
+			return;
+		}
+
+		resolver.resolve(internalState.getStateData());
+		pendingSharedStates.remove(event.getUniqueIdentifier());
 	}
 
 	private boolean serverSideForwardingToAam(final Event event) {
@@ -597,9 +608,38 @@ public final class AudienceExtension extends Extension {
 			return;
 		}
 
+		// prepare shared state for this asynchronous processing of this event
+		SharedStateResolver ssResolver = getApi().createPendingSharedState(event);
+		pendingSharedStates.put(event.getUniqueIdentifier(), ssResolver);
+
+		Map<String, String> signalData;
+
+		// if the event is a lifecycle event, convert the lifecycle keys to audience manager keys
+		if (EventType.LIFECYCLE.equals(event.getType())) {
+			Log.debug(LOG_TAG, LOG_SOURCE, "Lifecycle response event found, processing context data.");
+
+			final Map<String, String> tempLifecycleData = DataReader.optStringMap(
+				event.getEventData(),
+				AudienceConstants.EventDataKeys.Lifecycle.LIFECYCLE_CONTEXT_DATA,
+				null
+			);
+
+			signalData = getLifecycleDataForAudience(tempLifecycleData);
+		} else {
+			final Map<String, Object> customerEventData = event.getEventData();
+			signalData =
+				customerEventData == null
+					? null
+					: DataReader.optStringMap(
+						customerEventData,
+						AudienceConstants.EventDataKeys.Audience.VISITOR_TRAITS,
+						null
+					);
+		}
+
 		// generate the url to send
-		final String requestUrl = buildSignalUrl(server, event);
-		Log.debug(LOG_TAG, LOG_SOURCE, "Queuing request - %s", requestUrl);
+		final String requestUrl = buildSignalUrl(server, signalData, event);
+		Log.debug(LOG_TAG, LOG_SOURCE, "Queuing hit for url: %s", requestUrl);
 		AudienceDataEntity entity = new AudienceDataEntity(event, requestUrl, timeout);
 		hitQueue.queue(entity.toDataEntity());
 	}
@@ -778,21 +818,16 @@ public final class AudienceExtension extends Extension {
 	 * Customer provided KVPs are added as URL parameters to be used as traits for the signal.
 	 *
 	 * @param server {@link String} containing name of the server
-	 * @param event {@link Event} instance
+	 * @param signalData to convert in custom url variables
+	 * @param event current {@link Event} for which to retrieve required shared states
 	 * @return {@code String} representation of the URL to be used
 	 */
-	private String buildSignalUrl(final String server, final Event event) {
-		// get traits from event
-		final Map<String, Object> customerEventData = event.getEventData();
-		final Map<String, String> customerData = customerEventData == null
-			? null
-			: DataReader.optStringMap(customerEventData, AudienceConstants.EventDataKeys.Audience.VISITOR_TRAITS, null);
-
+	private String buildSignalUrl(final String server, final Map<String, String> signalData, final Event event) {
 		final String urlString = new URLBuilder()
 			.enableSSL(true)
 			.setServer(server)
 			.addPath(AudienceConstants.AUDIENCE_MANAGER_EVENT_PATH)
-			.addQuery(getCustomUrlVariables(customerData), URLBuilder.EncodeType.NONE)
+			.addQuery(getCustomUrlVariables(signalData), URLBuilder.EncodeType.NONE)
 			.addQuery(getDataProviderUrlVariables(event), URLBuilder.EncodeType.NONE)
 			.addQuery(getPlatformSuffix(), URLBuilder.EncodeType.NONE)
 			.addQuery(AudienceConstants.AUDIENCE_MANAGER_URL_PARAM_DST, URLBuilder.EncodeType.NONE)

--- a/code/audience/src/test/java/com/adobe/marketing/mobile/audience/AudienceExtensionTests.java
+++ b/code/audience/src/test/java/com/adobe/marketing/mobile/audience/AudienceExtensionTests.java
@@ -581,6 +581,7 @@ public class AudienceExtensionTests {
 		audience.handleLifecycleResponse(lifecycleEvent);
 
 		// verify
+		verify(mockExtensionApi).createPendingSharedState(any(Event.class));
 		ArgumentCaptor<DataEntity> entityCaptor = ArgumentCaptor.forClass(DataEntity.class);
 		verify(mockDataQueue).queue(entityCaptor.capture());
 		AudienceDataEntity audienceEntity = AudienceDataEntity.fromDataEntity(entityCaptor.getValue());
@@ -628,6 +629,7 @@ public class AudienceExtensionTests {
 
 		// verify
 		verify(mockExtensionApi, never()).dispatch(any(Event.class));
+		verify(mockExtensionApi).createPendingSharedState(any(Event.class));
 		ArgumentCaptor<DataEntity> entityCaptor = ArgumentCaptor.forClass(DataEntity.class);
 		verify(mockDataQueue).queue(entityCaptor.capture());
 		AudienceDataEntity audienceEntity = AudienceDataEntity.fromDataEntity(entityCaptor.getValue());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The Event Hub does not allow for setting shared states post current shared state cursor without setting a pending shared state first; error: "Cannot create com.adobe.module.audience shared state at version x. More recent state exists."
- Updated the source code to set a pending shared state when the current event is being queued and resolving it when the server response was received. 
- Additionally, for lifecycle response processing, queue the original event instead of a "fake audience request" to be able to handle pending shared states for known event numbers and resolve them.

This PR re-enables all tests 🎉 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
