### PR TITLE
Build the test app when merging code to staging and main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,15 @@ workflows:
           requires:
             - validate-code
 
+      - build-test-app:
+          requires:
+            - validate-code
+          filters:
+            branches:
+              only:
+                - main
+                - staging
+
 jobs:
   validate-code:
     # List of available Android Docker images: https://circleci.com/developer/images/image/cimg/android#image-tags
@@ -97,10 +106,6 @@ jobs:
       - run:
           name: Assemble Phone
           command: make assemble-phone
-
-      - run:
-          name: Assemble App
-          command: make assemble-app
 
       - android/run-tests:
           test-command: make unit-test-coverage
@@ -161,3 +166,25 @@ jobs:
       - codecov/upload:
           file: << pipeline.parameters.build-path >>/reports/coverage/androidTest/phone/debug/connected/report.xml
           flags: functional-tests
+
+  build-test-app:
+    executor:
+      name: android/android-docker
+      tag: 2024.01.1
+
+    steps:
+      - checkout
+
+      - android/restore-gradle-cache:
+          cache-prefix: << pipeline.parameters.gradle-cache-prefix >>
+      - android/restore-build-cache:
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>
+
+      - run:
+          name: Assemble App
+          command: make assemble-app
+
+      - android/save-gradle-cache:
+          cache-prefix: << pipeline.parameters.gradle-cache-prefix >>
+      - android/save-build-cache:
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>


### PR DESCRIPTION
To maintain consistency (https://github.com/adobe/aepsdk-edge-android/pull/144), we will only build the test app for main and staging PRs. 